### PR TITLE
profile_utils: use $PROFILE for getting psprofile file (extra: cargo lock version bump)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 4
 
 [[package]]
 name = "aleph"
-version = "0.0.45"
+version = "0.0.50"
 dependencies = [
  "mlua",
  "serde",


### PR DESCRIPTION
this solves the issue with being unable to install things on windows systems with one drive installed where the powershell profile is meant to reside in `$HOME/OneDrive/Documents/Powershell/....`  instead of the hardcoded location.

p.s. you forgot to build after updating cargo.toml