### PR TITLE
improve windows support and msi support edge cases

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2,31 +2,15 @@ use aleph::{cli::Action, AlephConfig};
 use std::env;
 
 fn main() {
-    // advertizes the os the program is running on
-
     #[cfg(target_os = "linux")]
     panic!("Invalid Platform");
 
+    // advertizes the os the program is running on
     println!(
         "Running on {} arch {}",
         std::env::consts::OS,
         std::env::consts::ARCH
     );
-
-    // The main driver progrem is incomplete
-    // use: cargo test --test install_test -- --ignored --show-output
-    // to run the install test that currenlty drives the installer
-
-    // [immediate]
-    // aleph search <search string>             # same as below
-    // aleph install <package name>             # if repo not found at ~/Documents/Aleph/__REPO call aleph fetch
-    // aleph fetch [opt: <url>]                  # fetches the latest commit from the scoop branch
-    // aleph --help                             # displays all the available sub commands
-    // aleph <subcommand> --help                # usage information for the subcommand
-    // aleph                                    # should just run aleph --help
-    //
-    // [FUTURE]
-    // aleph rebuild <config file>
 
     let config = AlephConfig::new();
 

--- a/src/powershell/utilities.rs
+++ b/src/powershell/utilities.rs
@@ -48,9 +48,7 @@ pub fn download_url(
             "-nv",
             url,
             "-P",
-            download_location
-                .to_str()
-                .expect("Failed to convert location to String"),
+            &format!("'{}'", download_location.display()),
         ])
         .output()
     else {

--- a/src/powershell/utilities.rs
+++ b/src/powershell/utilities.rs
@@ -44,6 +44,7 @@ pub fn download_url(
         .args([
             "-c",
             "wget",
+            "-N",
             "-nv",
             url,
             "-P",
@@ -125,7 +126,8 @@ pub fn get_wget(packages_path: &Path) -> PathBuf {
             "Invoke-WebRequest",
             &url,
             "-OutFile ",
-            file_path.to_str().unwrap(),
+            // fixes username having a space
+            &format!("'{}'", file_path.display()),
         ])
         .output()
     else {

--- a/src/scoopd/manifest_install.rs
+++ b/src/scoopd/manifest_install.rs
@@ -248,6 +248,32 @@ pub fn dependency_install(config: &AlephConfig, dependency: &str) -> Result<(), 
 }
 
 // ugly workaround will think of something later
+/* LICENSE FOR JSON CODE FOR 7zip from scoop main bucket
+This is free and unencumbered software released into the public domain.
+Anyone is free to copy, modify, publish, use, compile, sell, or
+distribute this software, either in source code form or as a compiled
+binary, for any purpose, commercial or non-commercial, and by any
+means.
+
+In jurisdictions that recognize copyright laws, the author or authors
+of this software dedicate any and all copyright interest in the
+software to the public domain. We make this dedication for the benefit
+of the public at large and to the detriment of our heirs and
+successors. We intend this dedication to be an overt act of
+relinquishment in perpetuity of all present and future rights to this
+software under copyright law.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT.
+IN NO EVENT SHALL THE AUTHORS BE LIABLE FOR ANY CLAIM, DAMAGES OR
+OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE,
+ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
+OTHER DEALINGS IN THE SOFTWARE.
+
+For more information, please refer to <http://unlicense.org/>
+*/
+
 const SEVENZIP_MANIFEST: &str = r#"{
     "version": "24.09",
     "description": "A multi-format file archiver with high compression ratios",

--- a/src/zipper.rs
+++ b/src/zipper.rs
@@ -132,23 +132,17 @@ pub fn extract_msi(archive: &Path, package_dir: &Path) -> Result<(), ExtractErro
         archive = new_archive;
     }
 
-    let archive = archive.to_str().ok_or(ExtractError::OsStrConversionError)?;
-    let package_dir = package_dir
-        .to_str()
-        .ok_or(ExtractError::OsStrConversionError)?
-        .to_owned()
-        + "\\";
-
-    println!("WARN support for msi installation is incomplete!");
     let output = Command::new("pwsh")
         .args([
             "-c",
             "msiexec.exe",
             "/i",
-            archive,
+            &format!("'{}'", archive.display()),
             "/passive",
-            // fixes username having a space .w.
-            &format!("INSTALLDIR='{package_dir}'"),
+            // fuck this crap how am I supposed to I need to escape with '`' kms
+            // still ain't working there's still something going wrong when
+            // the username has a space
+            &format!("INSTALLDIR=`\"{}`\"", package_dir.display()),
         ])
         .output()?;
 

--- a/src/zipper.rs
+++ b/src/zipper.rs
@@ -61,7 +61,6 @@ pub fn extract_archive(
     println!("Extracted archive successfully");
 
     strip_directory(package_dir)?;
-    //remove_file(archive)?;
 
     Ok(())
 }
@@ -117,6 +116,7 @@ pub fn extract_msi(archive: &Path, package_dir: &Path) -> Result<(), ExtractErro
 
     // okay so, if the fucking file name has a hiphen in it msiexec start shitting itself
     // on windows, who ever wrote msiexec was high.
+    println!("WARN support for msi installation is incomplete!");
     let mut archive = archive.to_path_buf();
     let file_name = archive
         .file_name()

--- a/tests/playground.rs
+++ b/tests/playground.rs
@@ -1,0 +1,8 @@
+use std::path::Path;
+
+#[test]
+#[ignore]
+fn playground() {
+    let path = Path::new("C:\\Users\\rexies").join("Hello World");
+    println!("{}", path.display());
+}

--- a/tests/playground.rs
+++ b/tests/playground.rs
@@ -1,8 +1,0 @@
-use std::path::Path;
-
-#[test]
-#[ignore]
-fn playground() {
-    let path = Path::new("C:\\Users\\rexies").join("Hello World");
-    println!("{}", path.display());
-}


### PR DESCRIPTION
msiexec: fixed failure to install packages when '-' in filename
wget: wget now overwrite existing files
zipper: cleanups
utilities: installation is now supported on paths with white spaces