### PR TITLE
Return auto removal of downloaded packages :<

### DIFF
--- a/src/powershell/utilities.rs
+++ b/src/powershell/utilities.rs
@@ -44,7 +44,8 @@ pub fn download_url(
         .args([
             "-c",
             "wget",
-            "-N",
+            //"-N", this is great but yeah if the file exists => no output from wget :(
+            // so till I figure something out we're stuck with this D:
             "-nv",
             url,
             "-P",
@@ -70,10 +71,12 @@ pub fn download_url(
 
         // Parses the exact file path
         let Some((_url, path)) = stderr.split_once('"') else {
-            println!("{stderr}");
+            println!("parse failure 1 {stderr}");
+            println!("{:?}", String::from_utf8(output.stdout).unwrap());
             return Err("Failed to parse wget output".to_string());
         };
         let Some((path, _)) = path.trim().split_once('"') else {
+            println!("parse failure 2 {stderr}");
             return Err("Failed to parse wget output".to_string());
         };
         // just to not cause weird inconsistencies

--- a/src/zipper.rs
+++ b/src/zipper.rs
@@ -61,6 +61,9 @@ pub fn extract_archive(
     println!("Extracted archive successfully");
 
     strip_directory(package_dir)?;
+    // no choice but to do this for now
+    // can be commented out when debugging I suppose
+    remove_file(archive)?;
 
     Ok(())
 }


### PR DESCRIPTION
seems like wget with the -N flag fails to produce an output that can be parsed
for that reason for the time being we will revert to removing downloaded archive after install